### PR TITLE
Fix relay count showing 4/4 connected after deleting all relays

### DIFF
--- a/lib/constants/relays.dart
+++ b/lib/constants/relays.dart
@@ -60,7 +60,7 @@ Future<List<String>> getRelaySetMainSockets() async {
   try {
     final prefs = await SharedPreferences.getInstance();
     final customRelays = prefs.getStringList('custom_main_relays');
-    if (customRelays != null && customRelays.isNotEmpty) {
+    if (customRelays != null) {
       return customRelays;
     }
   } catch (e) {


### PR DESCRIPTION
## Problem

When a user deletes all relays from the relay settings page, the UI still displays "4/4 connected" because the relay client silently re-initializes with the 4 default relays.

## Root Cause

`getRelaySetMainSockets()` in `lib/constants/relays.dart` treated an explicitly emptied relay list (`[]`) the same as a never-configured one (`null`), falling back to the default relays in both cases:

```dart
// Before (buggy)
if (customRelays != null && customRelays.isNotEmpty) {
  return customRelays;
}
return List.from(_defaultRelaySetMainSockets); // always hits for empty list
```

The chain of events:
1. User deletes all relays → `[]` is saved to SharedPreferences
2. `reloadCustomRelays()` calls `getRelaySetMainSockets()`
3. Empty list fails the `isNotEmpty` check → falls back to 4 defaults
4. Rust client reinitializes with defaults → status stream reports 4/4

## Fix

Remove the `isNotEmpty` check so that an explicitly saved empty list is respected as the user's choice. Defaults are only used when the preference key is absent (`null`), meaning the user has never customized their relays.

```dart
// After
if (customRelays != null) {
  return customRelays;
}
```

Fixes #19