### PR TITLE
fix: Move the div a little lower in the landscape mode (#12)

### DIFF
--- a/lib/ui/screens/auth/welcome_page.dart
+++ b/lib/ui/screens/auth/welcome_page.dart
@@ -127,8 +127,11 @@ class _WelcomePageState extends State<WelcomePage> {
       }
     }
 
+    final isLandscape =
+        MediaQuery.of(context).orientation == Orientation.landscape;
+
     return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 72, 16, 8),
+      padding: EdgeInsets.fromLTRB(16, isLandscape ? 16 : 72, 16, 8),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [


### PR DESCRIPTION
Reduces the top padding of the title section on the welcome page from 72px to 16px when in landscape orientation. This ensures the subtitle text ("A decentralized social network built on Nostr.") remains visible in landscape mode.

Fixes #12