### PR TITLE
fix relay count showing defaults after deleting all relays

### DIFF
--- a/lib/constants/relays.dart
+++ b/lib/constants/relays.dart
@@ -60,7 +60,7 @@ Future<List<String>> getRelaySetMainSockets() async {
   try {
     final prefs = await SharedPreferences.getInstance();
     final customRelays = prefs.getStringList('custom_main_relays');
-    if (customRelays != null && customRelays.isNotEmpty) {
+    if (customRelays != null) {
       return customRelays;
     }
   } catch (e) {


### PR DESCRIPTION
Fixes #19

**Problem:** After deleting all relays, the app still showed "4/4 connected" because `getRelaySetMainSockets()` treated an empty saved relay list the same as "never customized" and fell back to the 4 default relays.

**Root cause:** The condition `customRelays != null && customRelays.isNotEmpty` in `lib/constants/relays.dart` did not distinguish between:
- `null` — user never customized relays (should use defaults)
- `[]` — user explicitly removed all relays (should use empty list)

**Fix:** Removed the `isNotEmpty` check so an empty list is respected as the user's intent to have no relays.