### PR TITLE
fix: relay counter still shows 4/4 connected after deleting all relays

### DIFF
--- a/lib/constants/relays.dart
+++ b/lib/constants/relays.dart
@@ -60,7 +60,7 @@ Future<List<String>> getRelaySetMainSockets() async {
   try {
     final prefs = await SharedPreferences.getInstance();
     final customRelays = prefs.getStringList('custom_main_relays');
-    if (customRelays != null && customRelays.isNotEmpty) {
+    if (customRelays != null) {
       return customRelays;
     }
   } catch (e) {


### PR DESCRIPTION
### Problem

When a user deletes all relays, `SharedPreferences` stores an empty list (`[]`) under `'custom_main_relays'`. `getRelaySetMainSockets()` had the guard:

```dart
if (customRelays != null && customRelays.isNotEmpty) {
    return customRelays;
}
```

The `isNotEmpty` check caused the empty list to be skipped, falling through to return the 4 hard-coded default relays. Both callers — `RustRelayService.init()` and `RustRelayService.reloadCustomRelays()` — then reinitialised the Rust `nostr-sdk` client with all 4 defaults and connected to them, so `stream_relay_status` kept reporting `4/4 connected`.

### Fix

Drop the `isNotEmpty` condition in `getRelaySetMainSockets()` (`lib/constants/relays.dart`). A `null` value still triggers the defaults (first launch / never customised); a non-`null` value — whether empty or not — is now always honoured.

Fixes #19