### PR TITLE
feat: add eye icon to reveal/hide nsec and seed phrase on Keys screen

### DIFF
--- a/lib/l10n/app_de.arb
+++ b/lib/l10n/app_de.arb
@@ -192,6 +192,8 @@
   "shareThisToReceiveMessages": "Teilen Sie dies, um Nachrichten und Zaps zu erhalten.",
   "keepThisSecret": "Halten Sie dies geheim! Teilen Sie es niemals mit jemandem.",
   "useThisToRecoverAccount": "Verwenden Sie dies, um Ihr Konto wiederherzustellen. Bewahren Sie es sicher auf.",
+  "showKey": "Anzeigen",
+  "hideKey": "Verbergen",
   "advanced": "Erweitert",
   "keysTitle": "Schlüssel",
   "keysSubtitle": "Verwalten Sie Ihre Nostr-Identitätsschlüssel.",

--- a/lib/l10n/app_en.arb
+++ b/lib/l10n/app_en.arb
@@ -192,6 +192,8 @@
   "shareThisToReceiveMessages": "Share this with others to receive messages and zaps.",
   "keepThisSecret": "Keep this secret! Never share it with anyone.",
   "useThisToRecoverAccount": "Use this to recover your account. Store it safely.",
+  "showKey": "Show",
+  "hideKey": "Hide",
   "advanced": "Advanced",
   "keysTitle": "Keys",
   "keysSubtitle": "Manage your Nostr identity keys.",

--- a/lib/l10n/app_tr.arb
+++ b/lib/l10n/app_tr.arb
@@ -192,6 +192,8 @@
   "shareThisToReceiveMessages": "Mesaj ve zap almak için bunu paylaşın.",
   "keepThisSecret": "Bunu gizli tutun! Asla kimseyle paylaşmayın.",
   "useThisToRecoverAccount": "Hesabınızı kurtarmak için bunu kullanın. Güvenli bir şekilde saklayın.",
+  "showKey": "Göster",
+  "hideKey": "Gizle",
   "advanced": "Gelişmiş",
   "keysTitle": "Anahtarlar",
   "keysSubtitle": "Nostr kimlik anahtarlarınızı yönetin.",

--- a/lib/ui/screens/settings/keys_page.dart
+++ b/lib/ui/screens/settings/keys_page.dart
@@ -28,6 +28,8 @@ class _KeysPageState extends State<KeysPage> {
   String _mnemonic = '';
   String? _copiedKeyType;
   bool _showAdvanced = false;
+  bool _revealedNsec = false;
+  bool _revealedMnemonic = false;
 
   @override
   void initState() {
@@ -128,8 +130,10 @@ class _KeysPageState extends State<KeysPage> {
   }
 
   Widget _buildKeyDisplayCard(BuildContext context, String title, String value,
-      String keyType, bool isCopied, AppLocalizations l10n) {
-    final isMasked = keyType == 'mnemonic' || keyType == 'nsec';
+      String keyType, bool isCopied, AppLocalizations l10n,
+      {bool isRevealed = false, VoidCallback? onToggleReveal}) {
+    final isMasked =
+        (keyType == 'mnemonic' || keyType == 'nsec') && !isRevealed;
     final displayValue = isMasked ? '•' * 48 : value;
 
     String? description;
@@ -159,8 +163,10 @@ class _KeysPageState extends State<KeysPage> {
                 Expanded(
                   child: Text(
                     displayValue,
-                    maxLines: isMasked ? 3 : 1,
-                    overflow: TextOverflow.ellipsis,
+                    maxLines: isMasked ? 3 : null,
+                    overflow: isMasked
+                        ? TextOverflow.ellipsis
+                        : TextOverflow.visible,
                     style: TextStyle(
                       color: context.colors.textPrimary,
                       fontSize: 16,
@@ -170,13 +176,31 @@ class _KeysPageState extends State<KeysPage> {
                     ),
                   ),
                 ),
-                const SizedBox(width: 12),
+                if (onToggleReveal != null) ...[
+                  const SizedBox(width: 8),
+                  GestureDetector(
+                    onTap: onToggleReveal,
+                    child: Container(
+                      padding: const EdgeInsets.all(8),
+                      child: PhosphorIcon(
+                        isRevealed
+                            ? PhosphorIcons.eyeSlash()
+                            : PhosphorIcons.eye(),
+                        color: context.colors.iconSecondary,
+                        size: 20,
+                      ),
+                    ),
+                  ),
+                ],
+                const SizedBox(width: 4),
                 GestureDetector(
                   onTap: () => _copyToClipboard(value, keyType),
                   child: Container(
                     padding: const EdgeInsets.all(8),
-                    child:                       PhosphorIcon(
-                      isCopied ? PhosphorIcons.check() : PhosphorIcons.copy(),
+                    child: PhosphorIcon(
+                      isCopied
+                          ? PhosphorIcons.check()
+                          : PhosphorIcons.copy(),
                       color: isCopied
                           ? context.colors.success
                           : context.colors.iconSecondary,
@@ -267,6 +291,9 @@ class _KeysPageState extends State<KeysPage> {
                   'nsec',
                   _copiedKeyType == 'nsec',
                   l10n,
+                  isRevealed: _revealedNsec,
+                  onToggleReveal: () =>
+                      setState(() => _revealedNsec = !_revealedNsec),
                 ),
                 const SizedBox(height: 24),
               ],
@@ -277,6 +304,9 @@ class _KeysPageState extends State<KeysPage> {
                 'mnemonic',
                 _copiedKeyType == 'mnemonic',
                 l10n,
+                isRevealed: _revealedMnemonic,
+                onToggleReveal: () =>
+                    setState(() => _revealedMnemonic = !_revealedMnemonic),
               ),
               const SizedBox(height: 32),
               _buildAdvancedLink(context, l10n),


### PR DESCRIPTION
## Summary

Fixes #15

Users were unable to read their private key (nsec) or seed phrase directly in the app — the values were permanently masked with dots and the only option was to copy them to the clipboard and paste them into another app.

## Changes

### `lib/ui/screens/settings/keys_page.dart`
- Added `_revealedNsec` and `_revealedMnemonic` boolean state fields.
- Extended `_buildKeyDisplayCard` with optional `isRevealed` and `onToggleReveal` named parameters.
- When `onToggleReveal` is provided (i.e. for sensitive key types), a `PhosphorIcons.eye` / `PhosphorIcons.eyeSlash` icon is rendered beside the copy button.
- Tapping the eye icon toggles the boolean, switching between the masked placeholder (`••••••`) and the real key value.
- When revealed, `maxLines` is set to `null` and overflow to `TextOverflow.visible` so the full key/phrase wraps naturally.
- The public key (npub) is unaffected — it was already always visible.

### `lib/l10n/app_en.arb` / `app_tr.arb` / `app_de.arb`
- Added `showKey` and `hideKey` localisation strings (English, Turkish, German).

## Behaviour

| Key card | Before | After |
|---|---|---|
| Public key (npub) | Always visible | Unchanged |
| Private key (nsec) | Always masked | Eye icon toggles reveal |
| Seed phrase | Always masked | Eye icon toggles reveal |

The existing copy-warning dialog is preserved — users still see the security warning before copying a sensitive key to the clipboard.