### PR TITLE
fix: stop Following section re-fetch and rebuild when left menu opens

### DIFF
--- a/lib/presentation/blocs/sidebar/sidebar_bloc.dart
+++ b/lib/presentation/blocs/sidebar/sidebar_bloc.dart
@@ -15,6 +15,7 @@ class SidebarBloc extends Bloc<SidebarEvent, SidebarState> {
   final AuthService _authService;
   String? _currentUserHex;
   String? _currentNpub;
+  bool _isInitialized = false;
   StreamSubscription? _profileSubscription;
   Timer? _relayCountTimer;
   Timer? _countsTimer;
@@ -38,6 +39,14 @@ class SidebarBloc extends Bloc<SidebarEvent, SidebarState> {
     on<_SidebarAccountsLoaded>(_onAccountsLoaded);
   }
 
+  // ISSUE #17 FIX: `SidebarWidget.initState` dispatches this on EVERY drawer
+  // open (Flutter rebuilds the drawer subtree each open) and this bloc is a
+  // lazySingleton. Previously every open wiped the loaded state, re-fetched
+  // counts, re-subscribed to the profile stream, restarted polling, and leaked
+  // periodic timers. This handler is now idempotent: once initialized for the
+  // current user, subsequent opens are a no-op (the already-loaded state and
+  // running timers are reused), so the Following section no longer flashes a
+  // spinner or re-fetches when the menu opens.
   Future<void> _onSidebarInitialized(
     SidebarInitialized event,
     Emitter<SidebarState> emit,
@@ -48,7 +57,16 @@ class SidebarBloc extends Bloc<SidebarEvent, SidebarState> {
         return;
       }
 
-      _currentUserHex = pubkeyResult.data!;
+      final pubkeyHex = pubkeyResult.data!;
+
+      if (_isInitialized &&
+          _currentUserHex == pubkeyHex &&
+          state is SidebarLoaded) {
+        return;
+      }
+
+      _isInitialized = true;
+      _currentUserHex = pubkeyHex;
       _currentNpub =
           _authService.hexToNpub(_currentUserHex!) ?? _currentUserHex!;
 
@@ -118,6 +136,9 @@ class SidebarBloc extends Bloc<SidebarEvent, SidebarState> {
   void _loadFollowerCounts(String userPubkeyHex) {
     _fetchCounts(userPubkeyHex);
     _startFollowingPoll(userPubkeyHex);
+    // ISSUE #17: cancel any existing timer before reassigning so re-init never
+    // leaks/stacks periodic timers.
+    _countsTimer?.cancel();
     _countsTimer = Timer.periodic(const Duration(seconds: 30), (_) {
       _fetchCounts(userPubkeyHex);
     });
@@ -177,6 +198,9 @@ class SidebarBloc extends Bloc<SidebarEvent, SidebarState> {
 
   void _startRelayCountPolling() {
     _loadRelayCount();
+    // ISSUE #17: cancel any existing timer before reassigning so re-init never
+    // leaks/stacks periodic timers.
+    _relayCountTimer?.cancel();
     _relayCountTimer = Timer.periodic(const Duration(seconds: 10), (_) {
       _loadRelayCount();
     });

--- a/lib/ui/widgets/common/sidebar_widget.dart
+++ b/lib/ui/widgets/common/sidebar_widget.dart
@@ -22,11 +22,27 @@ class _SidebarWidgetState extends State<SidebarWidget> {
   late final SidebarBloc _sidebarBloc;
   bool _isSwitching = false;
 
+  // ISSUE #17 (Following section lag on drawer open):
+  // `SidebarWidget` is passed as `drawer: const SidebarWidget()` in feed_page.dart.
+  // Flutter builds/disposes the drawer's element subtree every time the drawer
+  // opens, so this State (and its `initState`) is recreated on EVERY open.
+  // `_sidebarBloc` is a lazySingleton (blocs_module.dart), so dispatching
+  // `SidebarInitialized` previously re-ran ALL of the bloc's initialization on
+  // each open (re-fetch counts, re-subscribe to profile, restart timers/poll,
+  // re-emit a blank loading state), causing the lag/flicker and the spinner
+  // re-appearing each open.
+  //
+  // FIX: the bloc's `_onSidebarInitialized` is now idempotent (no-ops once
+  // initialized for the current user). We also skip re-dispatching here when
+  // the bloc is already in `SidebarLoaded`, so a re-open reuses the cached
+  // state and running timers without touching the Following section.
   @override
   void initState() {
     super.initState();
     _sidebarBloc = AppDI.get<SidebarBloc>();
-    _sidebarBloc.add(const SidebarInitialized());
+    if (_sidebarBloc.state is! SidebarLoaded) {
+      _sidebarBloc.add(const SidebarInitialized());
+    }
   }
 
   Future<void> _handleAccountSwitch(BuildContext context, String npub) async {


### PR DESCRIPTION
## Summary

Fixes the lag/flicker in the left menu's **Following** section that occurred every time the drawer was opened.

## Root cause

The sidebar drawer is wired into the feed screen as `drawer: const SidebarWidget()`. Flutter builds and disposes the drawer's element subtree **every time the drawer opens**, so `_SidebarWidgetState.initState` runs on each open.

`SidebarBloc` is registered as a **lazySingleton**, but `initState` re-dispatched `SidebarInitialized` on every open. That re-ran the entire init flow against the singleton:

- `emit(SidebarLoaded(currentUser: {}))` wiped the loaded user map and reset `isLoadingCounts` to `true`, making the follower/following counts flash a spinner and the drawer rebuild from a blank state.
- `_loadFollowerCounts` → `_fetchCounts` issued a follower-count network request (Primal cache) plus a Rust DB following-list read on each open.
- `_startFollowingPoll` restarted a 1s × 15-attempt poll.
- `_countsTimer` (30s) and `_relayCountTimer` (10s) were reassigned **without cancelling** the previous instances, leaking/stacking periodic timers — each open added more timers all re-fetching, compounding the lag.
- The profile stream re-subscribed, background sync re-triggered, and every stored account's profile was re-fetched.

## Fix

- **Idempotent init:** added an `_isInitialized` guard so `_onSidebarInitialized` no-ops when already initialized for the current user and the state is already `SidebarLoaded`. No more redundant count fetches, re-subscribes, or blank-state re-emits on re-open.
- **Timer-leak fix:** `_countsTimer` and `_relayCountTimer` are now cancelled before reassignment so re-init can never stack duplicate periodic timers.
- **Widget-level guard:** `initState` only dispatches `SidebarInitialized` when the bloc isn't already in `SidebarLoaded`, so re-opening the drawer reuses the cached state and running timers without touching the Following section.

## Correctness across account switches

`SidebarBloc` is a lazySingleton. On account switch / logout, `AppDI.resetAndReinitialize()` calls `GetIt.reset()`, which disposes the old bloc (`bloc.close()`) and registers a fresh instance with `_isInitialized = false`. A new user therefore initializes normally — no stale state leaks across accounts.

## Behavior after fix

- First drawer open: full load as before.
- Subsequent opens: instant, reuses cached `SidebarLoaded` state — no network request, no DB re-read, no spinner flash, no timer churn.
- Background timers and the profile stream keep data fresh while the bloc lives; `SidebarRefreshed` still works for explicit refresh.

## Verification

- Both modified files parse cleanly (validated with `dart format`).
- A full `flutter analyze` could not complete in this environment due to a **pre-existing, unrelated** dependency conflict (`pubspec.yaml` pins `collection: ^1.19.1` while the bundled Flutter SDK's `integration_test` requires `1.19.0`), which blocks `pub get`. This is unrelated to the changes in this PR.

Closes #17