### PR TITLE
Fix sidebar avatar failing to load with no fallback

### DIFF
--- a/lib/ui/widgets/common/sidebar_widget.dart
+++ b/lib/ui/widgets/common/sidebar_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:phosphor_flutter/phosphor_flutter.dart';
 import 'package:go_router/go_router.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -153,33 +154,7 @@ class _UserProfileHeader extends StatelessWidget {
         children: [
           Row(
             children: [
-              Container(
-                width: 56,
-                height: 56,
-                decoration: BoxDecoration(
-                  shape: BoxShape.circle,
-                  color: colors.avatarPlaceholder,
-                  image: () {
-                    final profileImage = user['picture'] as String? ?? '';
-                    return profileImage.isNotEmpty
-                        ? DecorationImage(
-                            image: NetworkImage(profileImage),
-                            fit: BoxFit.cover,
-                          )
-                        : null;
-                  }(),
-                ),
-                child: () {
-                  final profileImage = user['picture'] as String? ?? '';
-                  return profileImage.isEmpty
-                      ? PhosphorIcon(
-                          PhosphorIcons.user(),
-                          size: 28,
-                          color: colors.textSecondary,
-                        )
-                      : null;
-                }(),
-              ),
+              _buildAvatar(),
               const SizedBox(width: 16),
               Expanded(
                 child: Column(
@@ -225,6 +200,42 @@ class _UserProfileHeader extends StatelessWidget {
           _buildFollowerInfo(context),
         ],
       ),
+    );
+  }
+
+  Widget _buildAvatar() {
+    const size = 56.0;
+    final profileImage = user['picture'] as String? ?? '';
+
+    final fallback = PhosphorIcon(
+      PhosphorIcons.user(),
+      size: 28,
+      color: colors.textSecondary,
+    );
+
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: colors.avatarPlaceholder,
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: profileImage.isEmpty
+          ? Center(child: fallback)
+          : CachedNetworkImage(
+              imageUrl: profileImage,
+              width: size,
+              height: size,
+              fit: BoxFit.cover,
+              fadeInDuration: Duration.zero,
+              fadeOutDuration: Duration.zero,
+              memCacheWidth: (size * 3).toInt(),
+              maxHeightDiskCache: (size * 3).toInt(),
+              maxWidthDiskCache: (size * 3).toInt(),
+              placeholder: (context, url) => Center(child: fallback),
+              errorWidget: (context, url, error) => Center(child: fallback),
+            ),
     );
   }
 


### PR DESCRIPTION
## Summary

The user avatar in the sidebar drawer could render as a permanently blank circle when the profile picture URL was set but failed to load.

## Root cause

In `_UserProfileHeader` (`lib/ui/widgets/common/sidebar_widget.dart`), the avatar was painted with a raw `NetworkImage` inside a `DecorationImage`:

- `NetworkImage` in a `BoxDecoration` has **no error handling** — a broken/expired/404/cleartext-blocked URL silently painted nothing.
- The fallback user icon was gated on `picture.isEmpty`, i.e. the URL *string*, not the actual load outcome. So a non-empty-but-failing URL took the "has picture" branch, set an image that never painted, and suppressed the fallback icon (`child: null`).
- The image was also uncached, unlike the rest of the app.

## Fix

Extracted a `_buildAvatar()` method that uses `CachedNetworkImage`, matching the existing pattern in `lib/ui/widgets/user/profile_info_widget.dart`:

- Memory + disk caching for the avatar.
- `placeholder` shows the Phosphor `user` icon while loading.
- `errorWidget` shows the Phosphor `user` icon on load failure.
- Null/empty picture URLs still fall back to the user icon.

## Testing

`dart format` parses the file cleanly (no syntax errors). A full `flutter analyze`/`pub get` could not run in this environment due to a pre-existing SDK constraint (a git dependency requires Dart >= 3.7.0 vs. the installed 3.6.0); this is unrelated to the change and `pubspec.yaml` was left untouched.