### PR TITLE
Fix uneven button border thickness on gossip-mode selector

### DIFF
--- a/lib/ui/screens/settings/relay_page.dart
+++ b/lib/ui/screens/settings/relay_page.dart
@@ -848,6 +848,7 @@ class _RelayPageState extends State<RelayPage> {
                       ? context.colors.switchActive
                       : Colors.transparent,
                   width: 1.5,
+                  strokeAlign: BorderSide.strokeAlignInside,
                 ),
               ),
               child: Text(


### PR DESCRIPTION
## Summary

The gossip-mode selector buttons (Normal / Aggressive / Psycho) on the relay settings page rendered their 1.5px border with uneven thickness on different sides and corners, as reported in issue #18.

## Root cause

In `lib/ui/screens/settings/relay_page.dart`, the `_buildGossipModeSelector` `Container` used a `BoxDecoration` with `Border.all(width: 1.5)` on a rounded corner (`BorderRadius.circular(12)`) without an explicit stroke alignment. The fractional stroke width rasterized inconsistently against the rounded corners, producing the uneven-thickness artifact.

## Fix

Added `strokeAlign: BorderSide.strokeAlignInside` to the `BorderSide` so the stroke is drawn entirely inside the container bounds and renders with uniform thickness on all sides and corners. This is a minimal, targeted change that preserves the existing visual design (same width, radius, colors, padding, and margin).

Closes #18